### PR TITLE
Combat log Punishments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.retromc</groupId>
     <artifactId>arenafighter</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
 
     <name>ArenaFighter</name>

--- a/src/main/java/org/garsooon/arenafighter/Arena/ArenaFighter.java
+++ b/src/main/java/org/garsooon/arenafighter/Arena/ArenaFighter.java
@@ -10,13 +10,6 @@ import org.garsooon.arenafighter.Fight.FightManager;
 import org.garsooon.arenafighter.Listeners.PlayerDeathListener;
 import org.garsooon.arenafighter.Listeners.PlayerQuitListener;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import static org.bukkit.Bukkit.getLogger;
 
 public class ArenaFighter extends JavaPlugin {

--- a/src/main/java/org/garsooon/arenafighter/Arena/ArenaFighter.java
+++ b/src/main/java/org/garsooon/arenafighter/Arena/ArenaFighter.java
@@ -10,6 +10,13 @@ import org.garsooon.arenafighter.Fight.FightManager;
 import org.garsooon.arenafighter.Listeners.PlayerDeathListener;
 import org.garsooon.arenafighter.Listeners.PlayerQuitListener;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import static org.bukkit.Bukkit.getLogger;
 
 public class ArenaFighter extends JavaPlugin {
@@ -31,7 +38,7 @@ public class ArenaFighter extends JavaPlugin {
         getCommand("arena").setExecutor(new ArenaCommand(arenaManager));
         getCommand("spectate").setExecutor(new SpectateCommand(fightManager));
         //TODO (Lowest Priority) automatically pull version info from pom.xml or plugin.yml
-        this.getCommand("fightabout").setExecutor(new FightAboutCommand("1.0.2", "Garsooon"));
+        this.getCommand("fightabout").setExecutor(new FightAboutCommand("1.0.3", "Garsooon"));
 
         // Register event listeners
         PluginManager pm = getServer().getPluginManager();
@@ -99,6 +106,9 @@ public class ArenaFighter extends JavaPlugin {
                 writer.write("      z: 200.5\n");
                 writer.write("      yaw: 180.0\n");
                 writer.write("      pitch: 0.0\n");
+                writer.write("      yaw: 180.0\n");
+                writer.write("      punishment:\n");
+                writer.write("        duration-minute: 5\n");
                 writer.close();
 
                 getLogger().info("Created default config.yml");
@@ -107,7 +117,7 @@ public class ArenaFighter extends JavaPlugin {
             }
         }
 
-        // For Beta 1.7.3, we don't have reloadConfig() method
+        // For Beta 1.7.3, we don't have reloadConfig() method like in modern
         // The ArenaManager will handle loading the config file directly
         getLogger().info("Configuration file ready for loading");
     }

--- a/src/main/java/org/garsooon/arenafighter/Commands/FightCommand.java
+++ b/src/main/java/org/garsooon/arenafighter/Commands/FightCommand.java
@@ -77,6 +77,23 @@ public class FightCommand implements CommandExecutor {
             return true;
         }
 
+        //TODO same issue as line 90
+        if (fightManager.isPunished(target)) {
+            challenger.sendMessage(ChatColor.RED + "This player has left a match recently and is not");
+            challenger.sendMessage(ChatColor.RED + "allowed to duel until their punishment is over.");
+            return true;
+        }
+
+        long remainingMillis = fightManager.getRemainingPunishment(challenger);
+        if (remainingMillis > 0) {
+            long minutes = (remainingMillis / 1000) / 60;
+            long seconds = (remainingMillis / 1000) % 60;
+            //TODO look into proper wrapping after "a" \n does not seem to wrap text, Condense to 1 .sendmessage afterwards
+            challenger.sendMessage(ChatColor.RED + "You are temporarily blocked from fighting due to leaving a");
+            challenger.sendMessage(ChatColor.RED + "match for " +ChatColor.YELLOW + minutes + "m " + seconds + "s" + ChatColor.RED + ".");
+            return true;
+        }
+
         if (fightManager.isInFight(target)) {
             challenger.sendMessage(ChatColor.RED + target.getName() + " is already in a fight.");
             return true;

--- a/src/main/java/org/garsooon/arenafighter/Fight/FightManager.java
+++ b/src/main/java/org/garsooon/arenafighter/Fight/FightManager.java
@@ -29,6 +29,10 @@ public class FightManager {
         this.spectatorOriginalLocations = new HashMap<>();
     }
 
+    public ArenaFighter getPlugin() {
+        return plugin;
+    }
+
     public boolean startFight(Player player1, Player player2) {
         if (isInFight(player1) || isInFight(player2)) {
             return false;

--- a/src/main/java/org/garsooon/arenafighter/Listeners/PlayerQuitListener.java
+++ b/src/main/java/org/garsooon/arenafighter/Listeners/PlayerQuitListener.java
@@ -22,16 +22,10 @@ public class PlayerQuitListener implements Listener {
     public void onPlayerQuit(PlayerQuitEvent event) {
         Player quitter = event.getPlayer();
 
-        // Cancel any ongoing fight
         if (fightManager.isInFight(quitter)) {
-            // Get the fight the quitting player is in
             Fight fight = fightManager.getFight(quitter);
             if (fight != null) {
-                // Get the other player as the winner
-                //TODO hook into eco wagers to give the wager to winner & spectators that bet on winner
                 Player winner = fight.getOtherPlayer(quitter);
-
-                // Broadcast Quitter message
                 if (winner != null && winner.isOnline()) {
                     fightManager.getPlugin().getServer().broadcastMessage(
                             winner.getName() + " &ewins! &f" + quitter.getName() + " &echickened out and left."
@@ -40,10 +34,9 @@ public class PlayerQuitListener implements Listener {
             }
 
             fightManager.cancelFight(quitter);
+            fightManager.punishQuitter(quitter); // apply punishment
         }
 
-        // Cancel any pending challenges involving the player
         fightCommand.cancelChallengesInvolving(quitter.getName());
     }
-
 }

--- a/src/main/java/org/garsooon/arenafighter/Listeners/PlayerQuitListener.java
+++ b/src/main/java/org/garsooon/arenafighter/Listeners/PlayerQuitListener.java
@@ -5,6 +5,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.garsooon.arenafighter.Commands.FightCommand;
+import org.garsooon.arenafighter.Fight.Fight;
 import org.garsooon.arenafighter.Fight.FightManager;
 
 public class PlayerQuitListener implements Listener {
@@ -19,14 +20,30 @@ public class PlayerQuitListener implements Listener {
 
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
-        Player player = event.getPlayer();
+        Player quitter = event.getPlayer();
 
         // Cancel any ongoing fight
-        if (fightManager.isInFight(player)) {
-            fightManager.cancelFight(player);
+        if (fightManager.isInFight(quitter)) {
+            // Get the fight the quitting player is in
+            Fight fight = fightManager.getFight(quitter);
+            if (fight != null) {
+                // Get the other player as the winner
+                //TODO hook into eco wagers to give the wager to winner & spectators that bet on winner
+                Player winner = fight.getOtherPlayer(quitter);
+
+                // Broadcast Quitter message
+                if (winner != null && winner.isOnline()) {
+                    fightManager.getPlugin().getServer().broadcastMessage(
+                            winner.getName() + " &ewins! &f" + quitter.getName() + " &echickened out and left."
+                    );
+                }
+            }
+
+            fightManager.cancelFight(quitter);
         }
 
         // Cancel any pending challenges involving the player
-        fightCommand.cancelChallengesInvolving(player.getName());
+        fightCommand.cancelChallengesInvolving(quitter.getName());
     }
+
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -26,45 +26,6 @@ arenas:
       yaw: 0
       pitch: 0.0
 
-  # May be deprecated on release
-  # Add more arenas like this:
-  # arena2:
-  #   world: world
-  #   spawn1:
-  #     x: 0.0
-  #     y: 64.0
-  #     z: 0.0
-  #     yaw: 0.0
-  #     pitch: 0.0
-  #   spawn2:
-  #     x: 10.0
-  #     y: 64.0
-  #     z: 0.0
-  #     yaw: 180.0
-  #     pitch: 0.0
-  #    spectatorSpawn:
-  #      x: 10
-  #      y: 64.0
-  #      z: 0
-  #      yaw: 0
-  #      pitch: 0.0
-
-  # Example arena found in Config.txt / property
-  #Arena Fighter Arenas Configuration
-  # Fri Jun 06 03:53:11 PDT 2025
-  #  test.spawn1.pitch=28.50003
-  #  test.spawn1.x=68.96249324060017
-  #  test.spawn1.y=10.0
-  #  test.spawn1.yaw=269.9995
-  #  test.spawn1.z=-367.31912943165753
-  #  test.spawn2.pitch=28.50003
-  #  test.spawn2.x=78.96249324060017
-  #  test.spawn2.y=10.0
-  #  test.spawn2.yaw=269.9995
-  #  test.spawn2.z=-367.31912943165753
-  #  test.spectator.pitch=28.50003
-  #  test.spectator.x=68
-  #  test.spectator.y=11
-  #  test.spectator.yaw=269.9995
-  #  test.spectator.z=-381.31912943165753
-  #  test.world=world
+#Combat logging punishment
+punishment:
+  duration-minutes: 5


### PR DESCRIPTION
Adds combat logging punishments. Punishments are configurable in minutes for when a player leaves a match in the config.yml. Players cannot challenge or be challenged by others during this time.

This sets the framework for wager support when a player leaves a wagered match.